### PR TITLE
Optionally pass JobCtx to job

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### dev (unpublished)
+* **Breaking change**: Jobs no longer explicitly get `JobCtx` as the first argument, as in 99.9% cases it doesn't need it. To pass JobCtx simply add `_ctx` to the signature of the function, and it will be passed implicitly
+* **Breaking change**: All cron jobs should be wrapped in `@task` decorator
+
 ### 0.0.3 (2020-02-25)
 * `.delay()` now returns `arq_redis.enqueue_job` result (`Optional[Job]`)
 * Add `py.typed` file

--- a/darq/utils.py
+++ b/darq/utils.py
@@ -1,6 +1,9 @@
 import inspect
+import typing as t
 
 from .types import AnyCallable
+
+JOB_CTX_KEYS = set(['job_id', 'job_try', 'enqueue_time', 'score'])
 
 
 def get_function_name(func: AnyCallable) -> str:
@@ -11,3 +14,15 @@ def get_function_name(func: AnyCallable) -> str:
             module_str = module.__spec__.name
 
     return f'{module_str}.{func.__name__}'
+
+
+def is_signature_has_param(func: AnyCallable, param: str) -> bool:
+    return param in inspect.signature(func).parameters
+
+
+def split_job_ctx_from_args(args: t.Sequence[t.Any]) -> t.Tuple:
+    ctx, args = None, list(args)
+    if args:
+        if isinstance(args[0], dict) and JOB_CTX_KEYS.intersection(args[0]):
+            ctx = args.pop(0)
+    return ctx, args


### PR DESCRIPTION
* **Breaking change**: Jobs no longer explicitly get `JobCtx` as the first argument, as in 99.9% cases it doesn't need it. To pass JobCtx simply add `_ctx` to the signature of the function, and it will be passed implicitly
* **Breaking change**: All cron jobs should be wrapped in `@task` decorator