### PR TITLE
Remove JobCtx param from job function signature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### dev (unpublished)
+* **Breaking change**: Jobs no longer explicitly get `JobCtx` as the first argument, as in 99.9% cases it doesn't need it. In future release will be possible to optionally pass JobCtx in some way.
+* **Breaking change**: All cron jobs should be wrapped in `@task` decorator
+* Directly pass `functions` to `arq.Worker`, not names.
+
 ### 0.0.3 (2020-02-25)
 * `.delay()` now returns `arq_redis.enqueue_job` result (`Optional[Job]`)
 * Add `py.typed` file

--- a/darq/app.py
+++ b/darq/app.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import importlib
 import typing as t
 
@@ -10,6 +11,7 @@ from arq.jobs import Job
 from .registry import Registry
 from .types import AnyCallable
 from .utils import get_function_name
+from .utils import split_job_ctx_from_args
 
 
 class DarqException(Exception):
@@ -40,10 +42,10 @@ class Darq:
                 '"queue_name" should not exist in config. '
                 'To specify queue in worker - use "-Q" arg in cli.',
             )
-        if not self.config.get('cron_jobs'):
-            self.config['cron_jobs'] = []
-        if not isinstance(self.config['cron_jobs'], list):
-            self.config['cron_jobs'] = list(self.config['cron_jobs'])
+
+        cron_jobs = self.config.pop('cron_jobs', [])
+        self.config['cron_jobs'] = []
+        self.add_cron_jobs(*cron_jobs)
 
         self.redis: t.Optional[arq.ArqRedis] = None
         if config.get('redis_pool'):
@@ -74,10 +76,30 @@ class Darq:
             importlib.import_module(pkg)
 
     def add_cron_jobs(self, *jobs: CronJob) -> None:
+        registered_coroutines = set(
+            arq_func.coroutine for arq_func in self.registry.values()
+        )
         for job in jobs:
             if not isinstance(job, CronJob):
-                raise ValueError(f'{job!r} must be instance of CronJob')
-        self.config['cron_jobs'].extend(jobs)
+                raise DarqException(f'{job!r} must be instance of CronJob')
+            if job.coroutine not in registered_coroutines:
+                raise DarqException(
+                    f'{job.coroutine!r} is not registered. '
+                    'Please, wrap it with @task decorator.',
+                )
+            self.config['cron_jobs'].append(job)
+
+    def wrap_job_coroutine(
+            self, function: t.Callable[..., t.Any],
+    ) -> t.Callable[..., t.Any]:
+
+        @functools.wraps(function)
+        async def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
+            ctx, splitted_args = split_job_ctx_from_args(args)
+            result = await function(*splitted_args, **kwargs)
+            return result
+
+        return wrapper
 
     def task(
             self,
@@ -90,6 +112,7 @@ class Darq:
     ) -> t.Any:
 
         def _decorate(function: AnyCallable) -> AnyCallable:
+            function = self.wrap_job_coroutine(function)
             name = get_function_name(function)
             worker_func = arq.worker.func(
                 coroutine=function, name=name, keep_result=keep_result,

--- a/darq/registry.py
+++ b/darq/registry.py
@@ -3,8 +3,6 @@ from collections import UserDict
 
 import arq
 
-from .utils import get_function_name
-
 if t.TYPE_CHECKING:
     BaseRegistry = UserDict[str, arq.worker.Function]
 else:
@@ -14,9 +12,10 @@ else:
 class Registry(BaseRegistry):
 
     def add(self, arq_function: arq.worker.Function) -> None:
-        coro = arq_function.coroutine
-        import_str = get_function_name(coro)
-        self[import_str] = arq_function
+        self[arq_function.name] = arq_function
+
+    def get_functions(self) -> t.Sequence[arq.worker.Function]:
+        return tuple(self.values())
 
     def get_function_names(self) -> t.Sequence[str]:
         return tuple(arq_func.name for arq_func in self.values())

--- a/darq/utils.py
+++ b/darq/utils.py
@@ -1,6 +1,10 @@
 import inspect
+import typing as t
 
 from .types import AnyCallable
+from .types import JobCtx
+
+JOB_CTX_KEYS = set(['job_id', 'job_try', 'enqueue_time', 'score'])
 
 
 def get_function_name(func: AnyCallable) -> str:
@@ -11,3 +15,13 @@ def get_function_name(func: AnyCallable) -> str:
             module_str = module.__spec__.name
 
     return f'{module_str}.{func.__name__}'
+
+
+def split_job_ctx_from_args(
+        args: t.Sequence[t.Any],
+) -> t.Tuple[t.Optional[JobCtx], t.List[t.Any]]:
+    ctx, args = None, list(args)
+    if args:
+        if isinstance(args[0], dict) and JOB_CTX_KEYS.intersection(args[0]):
+            ctx = args.pop(0)
+    return ctx, args

--- a/darq/worker.py
+++ b/darq/worker.py
@@ -27,7 +27,7 @@ class Worker(ArqWorker):
 
     def get_settings(self, queue: str) -> t.Dict[str, t.Any]:
         settings = {**self.darq_app.config}
-        settings['functions'] = self.darq_app.registry.get_function_names()
+        settings['functions'] = self.darq_app.registry.get_functions()
         if queue:
             settings['queue_name'] = queue
 


### PR DESCRIPTION
* **Breaking change**: Jobs no longer explicitly get `JobCtx` as the first argument, as in 99.9% cases it doesn't need it. In future release will be possible to optionally pass JobCtx in some way.
* **Breaking change**: All cron jobs should be wrapped in `@task` decorator
* Directly pass `functions` to `arq.Worker`, not names.