### PR TITLE
Add on_job_prerun / on_job_postrun callbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 0.2.0 (2020-02-26)
+* Add `on_job_prerun(ctx, function, args, kwargs)` and `on_job_postrun(ctx, function, args, kwargs, result)` callbacks.
+
 ### 0.1.0 (2020-02-26)
 * **Breaking change**: Jobs no longer explicitly get `JobCtx` as the first argument, as in 99.9% cases it doesn't need it. In future release will be possible to optionally pass JobCtx in some way.
 * **Breaking change**: All cron jobs should be wrapped in `@task` decorator

--- a/darq/utils.py
+++ b/darq/utils.py
@@ -1,10 +1,6 @@
 import inspect
-import typing as t
 
 from .types import AnyCallable
-from .types import JobCtx
-
-JOB_CTX_KEYS = set(['job_id', 'job_try', 'enqueue_time', 'score'])
 
 
 def get_function_name(func: AnyCallable) -> str:
@@ -15,13 +11,3 @@ def get_function_name(func: AnyCallable) -> str:
             module_str = module.__spec__.name
 
     return f'{module_str}.{func.__name__}'
-
-
-def split_job_ctx_from_args(
-        args: t.Sequence[t.Any],
-) -> t.Tuple[t.Optional[JobCtx], t.List[t.Any]]:
-    ctx, args = None, list(args)
-    if args:
-        if isinstance(args[0], dict) and JOB_CTX_KEYS.intersection(args[0]):
-            ctx = args.pop(0)
-    return ctx, args

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ async def arq_redis():
 
 
 @pytest.fixture
-async def worker_factory():
+async def worker_factory(arq_redis):
     worker_ = None
 
     async def create(darq, queue=None):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from unittest.mock import MagicMock
 
 import arq
 import pytest
@@ -12,7 +13,44 @@ from . import redis_settings
 darq_config = {'redis_settings': redis_settings, 'burst': True}
 
 
-async def foobar(a: int) -> int:
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+def assert_is_ctx(ctx):
+    assert isinstance(ctx, dict)
+    assert isinstance(ctx.get('redis'), ArqRedis)
+    assert isinstance(ctx.get('job_id'), str)
+
+
+def parse_log(records):
+    return re.sub(
+        r'\d+.\d\ds', 'X.XXs',
+        '\n'.join(r.message.strip() for r in records),
+    )
+
+
+def assert_worker_job_finished(
+        *, records, job_id, function_name, result, args, kwargs,
+):
+    call_args = []
+    if args:
+        call_args.append(', '.join(map(str, args)))
+    if kwargs:
+        call_args.append(', '.join([
+            f'{name}={param}' for name, param in kwargs.items()
+        ]))
+    call_str = ', '.join(call_args)
+    assert (
+        f'X.XXs → {job_id}:{function_name}({call_str})\n'
+        f'X.XXs ← {job_id}:{function_name} ● {result}'
+    ) in parse_log(records)
+
+
+async def foobar(a: int, enqueue_self=False) -> int:
+    if enqueue_self:
+        await foobar.delay(a + 1, _job_id='enqueue_self')
     return 42 + a
 
 
@@ -48,7 +86,7 @@ async def test_job_works_like_a_function():
 
 
 @pytest.mark.asyncio
-async def test_task_decorator(caplog, arq_redis, worker_factory):
+async def test_task_decorator(caplog, worker_factory):
     caplog.set_level(logging.INFO)
 
     darq = Darq(darq_config)
@@ -68,14 +106,10 @@ async def test_task_decorator(caplog, arq_redis, worker_factory):
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
 
-    log = re.sub(
-        r'\d+.\d\ds', 'X.XXs',
-        '\n'.join(r.message.strip() for r in caplog.records),
-    )
     assert (
         'X.XXs → testing:tests.test_app.foobar(a=1)\n'
         'X.XXs ← testing:tests.test_app.foobar ● 43'
-    ) in log
+    ) in parse_log(caplog.records)
 
 
 @pytest.mark.asyncio
@@ -98,6 +132,85 @@ async def test_task_parametrized():
     arq_func = darq.registry.get(func_name)
     assert isinstance(arq_func, arq.worker.Function)
     assert arq_func.name == func_name
-    assert arq_func.coroutine == foobar_task
+    assert arq_func.coroutine.__wrapped__ == foobar_task
     assert arq_func.timeout_s == timeout
     assert arq_func.keep_result_s == keep_result
+
+
+@pytest.mark.asyncio
+async def test_task_self_enqueue(caplog, worker_factory):
+    caplog.set_level(logging.INFO)
+
+    darq = Darq(darq_config)
+
+    foobar_task = darq.task(foobar)
+
+    await darq.connect()
+    await foobar_task.delay(1, _job_id='testing', enqueue_self=True)
+
+    worker = await worker_factory(darq)
+    await worker.main()
+
+    assert worker.jobs_complete == 2
+    assert (
+        'X.XXs → testing:tests.test_app.foobar(1, enqueue_self=True)\n'
+        'X.XXs ← testing:tests.test_app.foobar ● 43\n'
+        'X.XXs → enqueue_self:tests.test_app.foobar(2)\n'
+        'X.XXs ← enqueue_self:tests.test_app.foobar ● 44'
+    ) in parse_log(caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('args,kwargs,result', [
+    ((1,), {}, 43),
+    ((), {'a': 2}, 44),
+])
+async def test_on_job_callbacks(args, kwargs, result, caplog, worker_factory):
+    caplog.set_level(logging.INFO)
+
+    on_job_prerun = AsyncMock()
+    on_job_prerun.__bool__ = lambda self: True
+
+    on_job_postrun = AsyncMock()
+    on_job_postrun.__bool__ = lambda self: True
+
+    darq = Darq(
+        darq_config,
+        on_job_prerun=on_job_prerun,
+        on_job_postrun=on_job_postrun,
+    )
+
+    foobar_task = darq.task(foobar)
+
+    await darq.connect()
+    job_id = 'testing'
+    await foobar_task.delay(*args, _job_id=job_id, **kwargs)
+
+    worker = await worker_factory(darq)
+    await worker.main()
+
+    assert_worker_job_finished(
+        records=caplog.records,
+        job_id=job_id,
+        function_name='tests.test_app.foobar',
+        result=result,
+        args=args,
+        kwargs=kwargs,
+    )
+
+    on_job_prerun.assert_called_once()
+    call_args = on_job_prerun.call_args[0]
+    assert len(call_args) == 4  # ctx, function, args, kwargs
+    assert_is_ctx(call_args[0])
+    assert call_args[1] == foobar_task
+    assert call_args[2] == args
+    assert call_args[3] == kwargs
+
+    on_job_postrun.assert_called_once()
+    call_args = on_job_postrun.call_args[0]
+    assert len(call_args) == 5  # ctx, function, args, kwargs, result
+    assert_is_ctx(call_args[0])
+    assert call_args[1] == foobar_task
+    assert call_args[2] == args
+    assert call_args[3] == kwargs
+    assert call_args[4] == result


### PR DESCRIPTION
Add `on_job_prerun(ctx, function, args, kwargs)` and `on_job_postrun(ctx, function, args, kwargs, result)` callbacks.