### PR TITLE
Pass arq_function instead of function to on_job_prerun/on_job_postrun

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 0.3.0 (2020-02-27)
+* **Breaking change**: `on_job_prerun` and `on_job_postrun` now accepts `arq.worker.Function` instead of the original function (it can still be accessed at `arq_function.coroutine`)
+
 ### 0.2.1 (2020-02-26)
 * Fix `add_cron_jobs` method. Tests added.
 

--- a/darq/registry.py
+++ b/darq/registry.py
@@ -3,6 +3,8 @@ from collections import UserDict
 
 import arq
 
+from .types import AnyCallable
+
 if t.TYPE_CHECKING:
     BaseRegistry = UserDict[str, arq.worker.Function]
 else:
@@ -10,6 +12,29 @@ else:
 
 
 class Registry(BaseRegistry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.by_original_coro: t.Dict[AnyCallable, arq.worker.Function] = {}
+
+    def __setitem__(
+            self, arq_function_name: str, arq_function: arq.worker.Function,
+    ) -> None:
+        original_coroutine = t.cast(
+            AnyCallable,
+            arq_function.coroutine.__wrapped__,  # type: ignore
+        )
+        self.by_original_coro[original_coroutine] = arq_function
+        self.data[arq_function_name] = arq_function
+
+    def __delitem__(self, arq_function_name: str) -> None:
+        arq_function = self.data[arq_function_name]
+        original_coroutine = t.cast(
+            AnyCallable,
+            arq_function.coroutine.__wrapped__,  # type: ignore
+        )
+        del self.by_original_coro[original_coroutine]
+        del self.data[arq_function_name]
 
     def add(self, arq_function: arq.worker.Function) -> None:
         self[arq_function.name] = arq_function

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = '\n\n'.join((
 
 setuptools.setup(
     name='darq',
-    version='0.2.1',
+    version='0.3.0',
     author='Igor Mozharovsky',
     author_email='igor.mozharovsky@gmail.com',
     description='A small wrapper around arq',


### PR DESCRIPTION
* **Breaking change**: `on_job_prerun` and `on_job_postrun` now accepts `arq.worker.Function` instead of the original function (it can still be accessed at `arq_function.coroutine`)