### PR TITLE
Add default_job_expires param

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 0.4.0 (2020-03-03)
+* Add `default_job_expires` param to Darq (if the job still hasn't started after this duration, do not run it). Default - 1 day
+* Add `expires` param to `@task` (if set - overwrites `default_job_expires`)
+
 ### 0.3.1 (2020-03-02)
 * Rewrite warm shutdown: now during warm shutdown cron is disabled, on second signal the warm shutdown will be canceled
 

--- a/darq/types.py
+++ b/darq/types.py
@@ -10,6 +10,7 @@ else:
     from typing_extensions import TypedDict
 
 AnyCallable = t.Callable[..., t.Any]
+AnyTimedelta = t.Union[int, float, datetime.timedelta]
 
 
 class JobCtx(TypedDict):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-asyncio
+asynctest
 mypy
 flake8
 flake8-quotes


### PR DESCRIPTION
* Add `default_job_expires` param to Darq (if the job still hasn't started after this duration, do not run it). Default - 1 day
* Add `expires` param to `@task` (if set - overwrites `default_job_expires`)
